### PR TITLE
refactor: replace manual bootstrap with DI container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,22 @@ dotnet watch test
 
 **.NET 10 / Avalonia 11 desktop app (MVVM).** No web server, no API — pure desktop with Microsoft Graph API for OneDrive access.
 
-### Bootstrap (no DI container)
+### Bootstrap
 
-`App.axaml.cs` is the composition root. `BootstrapAsync` manually wires all services and assigns them to static properties on `App` (e.g., `App.Auth`, `App.SyncService`, `App.Repository`). There is no `IServiceProvider` — ViewModels receive dependencies via constructor injection from `MainWindow.InitialiseAsync`.
+`App.axaml.cs` is the composition root. `BootstrapAsync` builds a `Microsoft.Extensions.DependencyInjection` `ServiceProvider` and resolves all services from it. Service registrations live in `Services/ServiceCollectionExtensions.cs` (`AddOneDriveSyncServices`).
+
+Bootstrap order matters:
+1. `SettingsService.LoadAsync()` — async factory, pre-loaded before container build and registered as a singleton instance
+2. `ServiceCollection` built, `ServiceProvider` stored in `App._serviceProvider`
+3. `ILocalizationService.InitialiseAsync` called
+4. `IThemeService.Apply` called with saved theme
+5. `AppDbContext` resolved, `MigrateAsync()` run
+6. `MainWindowViewModel` resolved (transient), passed to `MainWindow.InitialiseAsync`
+7. `SyncScheduler.Start` called with saved interval
+
+`ServiceProvider` is disposed on app exit via `desktop.Exit`, which automatically disposes singleton `IAsyncDisposable` services (e.g., `SyncScheduler`).
+
+**Lifetimes:** all services are `Singleton` except `MainWindowViewModel` which is `Transient`. No `Scoped` — there is no HTTP scope in a desktop app.
 
 ### Navigation
 
@@ -82,7 +95,7 @@ Avalonia value converters in `src/.../Converters/`. `SyncState` enum drives badg
 
 ### Localization
 
-JSON-based; `en-GB.json` is the only locale. `LocalizationService` loads it as an embedded resource. Accessed globally via `App.Localisation`.
+JSON-based; `en-GB.json` is the only locale. `LocalizationService` loads it as an embedded resource. Resolved via `ILocalizationService` from the DI container.
 
 ### Settings
 

--- a/src/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client/App.axaml.cs
@@ -1,45 +1,35 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using AStar.Dev.OneDrive.Sync.Client.Data;
-using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Services;
-using AStar.Dev.OneDrive.Sync.Client.Services.Auth;
-using AStar.Dev.OneDrive.Sync.Client.Services.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Services.Localization;
 using AStar.Dev.OneDrive.Sync.Client.Services.Settings;
-using AStar.Dev.OneDrive.Sync.Client.Services.Startup;
 using AStar.Dev.OneDrive.Sync.Client.Services.Sync;
+using AStar.Dev.OneDrive.Sync.Client.ViewModels;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AStar.Dev.OneDrive.Sync.Client;
 
 [ExcludeFromCodeCoverage]
 public partial class App : Application
 {
-    private const string AppName    = "AStar.Dev.OneDrive.Sync";
-    public static ILocalizationService Localisation { get; private set; } = null!;
-    public static IThemeService Theme { get; private set; } = null!;
-    public static IAuthService Auth { get; private set; } = null!;
-    public static IAccountRepository Repository { get; private set; } = null!;
-    public static ISyncService SyncService { get; private set; } = null!;
-    public static SyncScheduler Scheduler { get; private set; } = null!;
-    public static ISettingsService AppSettings { get; private set; } = null!;
+    private const string AppName = "AStar.Dev.OneDrive.Sync";
+
+    private static ServiceProvider? _serviceProvider;
 
     public override void Initialize() => AvaloniaXamlLoader.Load(this);
 
     public static string GetPlatformUserDataDirectory(string email)
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
         var safeEmail = string.Concat(email.Split(Path.GetInvalidFileNameChars()));
+
         return OperatingSystem.IsWindows()
-            ? Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                AppName,
-                safeEmail)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), AppName, safeEmail)
             : OperatingSystem.IsMacOS()
                 ? Path.Combine(home, "Library", "Application Support", AppName, safeEmail)
                 : Path.Combine(home, ".config", AppName, safeEmail);
@@ -58,8 +48,8 @@ public partial class App : Application
 
             desktop.Exit += async (_, _) =>
             {
-                if(Scheduler is not null)
-                    await Scheduler.DisposeAsync();
+                if(_serviceProvider is not null)
+                    await _serviceProvider.DisposeAsync();
 
                 Serilog.Log.Information("[App] Application exiting");
                 Serilog.Log.CloseAndFlush();
@@ -71,38 +61,26 @@ public partial class App : Application
     {
         try
         {
-            var locService = new LocalizationService();
+            ISettingsService settings = await SettingsService.LoadAsync();
+
+            var services = new ServiceCollection();
+            _ = services.AddOneDriveSyncServices(settings);
+            _serviceProvider = services.BuildServiceProvider();
+
+            ILocalizationService locService = _serviceProvider.GetRequiredService<ILocalizationService>();
             await locService.InitialiseAsync(new CultureInfo("en-GB"));
-            Localisation = locService;
 
-            SettingsService settingsService = await SettingsService.LoadAsync();
-            AppSettings = settingsService;
+            IThemeService themeService = _serviceProvider.GetRequiredService<IThemeService>();
+            themeService.Apply(settings.Current.Theme);
 
-            var themeService = new ThemeService();
-            themeService.Apply(settingsService.Current.Theme);
-            Theme = themeService;
-
-            AppDbContext db = DbContextFactory.Create();
+            AppDbContext db = _serviceProvider.GetRequiredService<AppDbContext>();
             await db.Database.MigrateAsync();
-            var accountRepository = new AccountRepository(db);
-            var syncRepository    = new SyncRepository(db);
-            Repository = accountRepository;
 
-            var tokenCache  = new TokenCacheService();
-            var authService = new AuthService(tokenCache);
-            Auth = authService;
+            MainWindowViewModel vm = _serviceProvider.GetRequiredService<MainWindowViewModel>();
+            await window.InitialiseAsync(vm);
 
-            var graphService   = new GraphService();
-            var syncService    = new SyncService(authService, graphService, accountRepository, syncRepository);
-            var scheduler      = new SyncScheduler(syncService, accountRepository);
-            SyncService = syncService;
-            Scheduler = scheduler;
-
-            var startupService = new StartupService(accountRepository, authService);
-
-            await window.InitialiseAsync(authService, graphService, startupService, syncService, scheduler, syncRepository, settingsService, accountRepository);
-
-            scheduler.Start(TimeSpan.FromMinutes(settingsService.Current.SyncIntervalMinutes));
+            SyncScheduler scheduler = _serviceProvider.GetRequiredService<SyncScheduler>();
+            scheduler.Start(TimeSpan.FromMinutes(settings.Current.SyncIntervalMinutes));
         }
         catch(Exception ex)
         {

--- a/src/AStar.Dev.OneDrive.Sync.Client/Localization/ILocalizationService.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client/Localization/ILocalizationService.cs
@@ -27,6 +27,12 @@ public interface ILocalizationService
     string Get(string key, params object[] args);
 
     /// <summary>
+    /// Loads strings for the requested culture at startup (or en-GB as fallback).
+    /// Does not raise <see cref="CultureChanged"/>.
+    /// </summary>
+    Task InitialiseAsync(CultureInfo? requested = null);
+
+    /// <summary>
     /// Switches the active culture and reloads strings.
     /// Raises <see cref="CultureChanged"/>.
     /// </summary>

--- a/src/AStar.Dev.OneDrive.Sync.Client/MainWindow.axaml.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client/MainWindow.axaml.cs
@@ -1,10 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
-using AStar.Dev.OneDrive.Sync.Client.Services.Auth;
-using AStar.Dev.OneDrive.Sync.Client.Services.Graph;
-using AStar.Dev.OneDrive.Sync.Client.Services.Settings;
-using AStar.Dev.OneDrive.Sync.Client.Services.Startup;
-using AStar.Dev.OneDrive.Sync.Client.Services.Sync;
 using AStar.Dev.OneDrive.Sync.Client.ViewModels;
 using Avalonia.Controls;
 
@@ -13,17 +7,11 @@ namespace AStar.Dev.OneDrive.Sync.Client;
 [ExcludeFromCodeCoverage]
 public partial class MainWindow : Window
 {
-    private MainWindowViewModel? _vm;
-
     public MainWindow() => InitializeComponent();
 
-    public async Task InitialiseAsync(IAuthService authService, IGraphService graphService, IStartupService startupService, ISyncService syncService, SyncScheduler scheduler, ISyncRepository syncRepository,
-                                      ISettingsService settingsService, IAccountRepository accountRepository)
+    public async Task InitialiseAsync(MainWindowViewModel vm)
     {
-        _vm = new MainWindowViewModel(authService, graphService, startupService, syncService, scheduler, syncRepository, settingsService, accountRepository);
-
-        DataContext = _vm;
-
-        await _vm.InitialiseAsync();
+        DataContext = vm;
+        await vm.InitialiseAsync();
     }
 }

--- a/src/AStar.Dev.OneDrive.Sync.Client/Services/ServiceCollectionExtensions.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client/Services/ServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using AStar.Dev.OneDrive.Sync.Client.Data;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
+using AStar.Dev.OneDrive.Sync.Client.Services.Auth;
+using AStar.Dev.OneDrive.Sync.Client.Services.Graph;
+using AStar.Dev.OneDrive.Sync.Client.Services.Localization;
+using AStar.Dev.OneDrive.Sync.Client.Services.Settings;
+using AStar.Dev.OneDrive.Sync.Client.Services.Startup;
+using AStar.Dev.OneDrive.Sync.Client.Services.Sync;
+using AStar.Dev.OneDrive.Sync.Client.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Services;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddOneDriveSyncServices(this IServiceCollection services, ISettingsService settings)
+    {
+        _ = services.AddSingleton(settings);
+        _ = services.AddSingleton<ILocalizationService, LocalizationService>();
+        _ = services.AddSingleton<IThemeService, ThemeService>();
+        _ = services.AddSingleton<TokenCacheService>();
+        _ = services.AddSingleton<IAuthService, AuthService>();
+        _ = services.AddSingleton<IGraphService, GraphService>();
+        _ = services.AddSingleton(_ => DbContextFactory.Create());
+        _ = services.AddSingleton<IAccountRepository, AccountRepository>();
+        _ = services.AddSingleton<ISyncRepository, SyncRepository>();
+        _ = services.AddSingleton<ISyncService, SyncService>();
+        _ = services.AddSingleton<IStartupService, StartupService>();
+        _ = services.AddSingleton<SyncScheduler>();
+        _ = services.AddTransient<MainWindowViewModel>();
+
+        return services;
+    }
+}

--- a/src/AStar.Dev.OneDrive.Sync.Client/ViewModels/DashboardViewModel.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client/ViewModels/DashboardViewModel.cs
@@ -1,11 +1,12 @@
 using System.Collections.ObjectModel;
+using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Models;
 using AStar.Dev.OneDrive.Sync.Client.Services.Sync;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace AStar.Dev.OneDrive.Sync.Client.ViewModels;
 
-public sealed partial class DashboardViewModel(SyncScheduler scheduler) : ObservableObject
+public sealed partial class DashboardViewModel(SyncScheduler scheduler, IAccountRepository accountRepository) : ObservableObject
 {
     public ObservableCollection<DashboardAccountViewModel> AccountSections { get; } = [];
 
@@ -34,7 +35,7 @@ public sealed partial class DashboardViewModel(SyncScheduler scheduler) : Observ
         if(AccountSections.Any(s => s.AccountId == account.Id))
             return;
 
-        var section = new DashboardAccountViewModel(account, scheduler, App.Repository);
+        var section = new DashboardAccountViewModel(account, scheduler, accountRepository);
 
         AccountSections.Add(section);
 

--- a/src/AStar.Dev.OneDrive.Sync.Client/ViewModels/MainWindowViewModel.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using AStar.Dev.OneDrive.Sync.Client.Data.Entities;
 using AStar.Dev.OneDrive.Sync.Client.Data.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Models;
+using AStar.Dev.OneDrive.Sync.Client.Services;
 using AStar.Dev.OneDrive.Sync.Client.Services.Auth;
 using AStar.Dev.OneDrive.Sync.Client.Services.Graph;
 using AStar.Dev.OneDrive.Sync.Client.Services.Settings;
@@ -21,7 +22,8 @@ public sealed partial class MainWindowViewModel(
     SyncScheduler scheduler,
     ISyncRepository syncRepository,
     ISettingsService settingsService,
-    IAccountRepository accountRepository) : ObservableObject
+    IAccountRepository accountRepository,
+    IThemeService themeService) : ObservableObject
 {
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDashboardActive))]
@@ -109,15 +111,15 @@ public sealed partial class MainWindowViewModel(
         }
     }
 
-    public AccountsViewModel Accounts { get; } = new(authService, graphService, App.Repository);
+    public AccountsViewModel Accounts { get; } = new(authService, graphService, accountRepository);
 
-    public FilesViewModel Files { get; } = new(authService, graphService, App.Repository);
+    public FilesViewModel Files { get; } = new(authService, graphService, accountRepository);
 
     public ActivityViewModel Activity { get; } = new(syncService, syncRepository);
 
-    public DashboardViewModel Dashboard { get; } = new(scheduler);
+    public DashboardViewModel Dashboard { get; } = new(scheduler, accountRepository);
 
-    public SettingsViewModel Settings { get; } = new(settingsService, App.Theme, scheduler, accountRepository);
+    public SettingsViewModel Settings { get; } = new(settingsService, themeService, scheduler, accountRepository);
 
     public StatusBarViewModel StatusBar { get; } = new();
 
@@ -173,7 +175,7 @@ public sealed partial class MainWindowViewModel(
         if(active is null)
             return;
 
-        AccountEntity? entity = await App.Repository.GetByIdAsync(active.Id);
+        AccountEntity? entity = await accountRepository.GetByIdAsync(active.Id);
         if(entity is null)
             return;
 


### PR DESCRIPTION
Static App.* service accessors removed. BootstrapAsync now builds a Microsoft.Extensions.DependencyInjection ServiceProvider; all services registered in ServiceCollectionExtensions.AddOneDriveSyncServices.

SettingsService pre-loaded before container build (async factory constraint) then registered as a singleton instance. ServiceProvider disposed on app exit, which propagates to IAsyncDisposable singletons (SyncScheduler). All lifetimes are Singleton except MainWindowViewModel (Transient).